### PR TITLE
run service as cryptpad_user, not as root

### DIFF
--- a/templates/cryptpad.service.j2
+++ b/templates/cryptpad.service.j2
@@ -2,6 +2,7 @@
 Description=CryptPad service
 
 [Service]
+User={{ cryptpad_user }}
 ExecStart=/usr/bin/node {{ cryptpad_path }}/server.js
 WorkingDirectory={{ cryptpad_path }}
 Restart=always


### PR DESCRIPTION
cryptpad service is running as root user, this patch use {{ cryptpad_user }}