### PR TITLE
script-src CSP

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,8 +38,8 @@
     state: present
     filename: 'nodesource'
   with_items:
-    - "deb https://deb.nodesource.com/node_6.x {{ ansible_distribution_release }} main"
-    - "deb-src https://deb.nodesource.com/node_6.x {{ ansible_distribution_release }} main"
+    - "deb https://deb.nodesource.com/node_12.x {{ ansible_distribution_release }} main"
+    - "deb-src https://deb.nodesource.com/node_12.x {{ ansible_distribution_release }} main"
 
 - name: ensure required packages are installed
   apt:

--- a/templates/config.js.j2
+++ b/templates/config.js.j2
@@ -62,8 +62,8 @@ module.exports = {
     padContentSecurity: [
         "default-src 'none'",
         "style-src 'unsafe-inline' 'self'" + domain,
-        // Unsafe inline, unsafe-eval are needed for ckeditor :(
-        "script-src 'self' 'unsafe-eval' 'unsafe-inline'" + domain,
+        
+        "script-src 'self'" + domain,
         "font-src 'self'" + domain,
 
         /*  See above under 'contentSecurity' as to how these values should be


### PR DESCRIPTION
Tested on debian buster : 

The properties 'unsafe-eval' and 'unsafe-inline' in script-src causes bugs with CSP (Toolbar of ckeditor doesn't work),  preventing Sheets to work when installing.

